### PR TITLE
Redraw the view after an orientation change

### DIFF
--- a/Classes/GDIIndexBar.m
+++ b/Classes/GDIIndexBar.m
@@ -351,6 +351,7 @@ CGPoint CGPointAdd(CGPoint point1, CGPoint point2) {
 - (void)deviceOrientationDidChange
 {
     [self setNeedsLayout];
+    [self setNeedsDisplay];
 }
 
 


### PR DESCRIPTION
When subclassing the view an overriding `layoutSubviews` (to use autolayout for example), the view is not redrawn after an orientation change.
The call to `setNeedDisplay` is currently done in `layoutSubview`. This PR propose to add a call to `setNeedDisplay` in `deviceOrientationDidChange`. There will be no performance cost when using the vanilla GDIIndexBar, as the `setNeedDisplay` calls are buffered and the view will be redrawn just once.
